### PR TITLE
DDF-2861 Add integration test for route manager

### DIFF
--- a/distribution/ddf/pom.xml
+++ b/distribution/ddf/pom.xml
@@ -107,6 +107,9 @@
                                 <descriptor>
                                     mvn:org.apache.karaf.features/enterprise/${karaf.version}/xml/features
                                 </descriptor>
+                                <descriptor>
+                                    mvn:org.codice.ddf.broker/broker-app/${project.version}/xml/features
+                                </descriptor>
                             </descriptors>
                             <repository>${setup.folder}/${karaf.folder}/system</repository>
                         </configuration>

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -40,6 +40,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Dictionary;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -61,6 +62,8 @@ import org.ops4j.pax.exam.MavenUtils;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.karaf.options.KarafDistributionOption;
 import org.ops4j.pax.exam.karaf.options.LogLevelOption;
+import org.osgi.framework.BundleException;
+import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.metatype.MetaTypeService;
 import org.slf4j.Logger;
@@ -651,5 +654,15 @@ public abstract class AbstractIntegrationTest {
 
     public void configureRestForBasic(String whitelist) throws Exception {
         getSecurityPolicy().configureRestForBasic(whitelist);
+    }
+
+    protected void configureBundle(String bundleName, String pid,
+            Dictionary<String, Object> properties)
+            throws IOException, BundleException, InterruptedException {
+        getServiceManager().stopBundle(bundleName);
+        Configuration config = configAdmin.getConfiguration(pid, null);
+        config.update(properties);
+        getServiceManager().startBundle(bundleName);
+        getServiceManager().waitForAllBundles();
     }
 }

--- a/distribution/test/itests/test-itests-common/src/main/resources/sdk-example-route.xml
+++ b/distribution/test/itests/test-itests-common/src/main/resources/sdk-example-route.xml
@@ -1,0 +1,6 @@
+<routes xmlns="http://camel.apache.org/schema/spring">
+    <route id="sdk-example-router">
+        <from uri="sjms:jms.queue.sdk.example"/>
+        <to uri="sjms:topic:jms.topic.sdk.example"/>
+    </route>
+</routes>

--- a/distribution/test/itests/test-itests-ddf/pom.xml
+++ b/distribution/test/itests/test-itests-ddf/pom.xml
@@ -197,25 +197,25 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core</artifactId>
-            <version>2.18.0</version>
+            <version>${camel.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-amqp</artifactId>
-            <version>2.18.0</version>
+            <version>${camel.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-sjms</artifactId>
-            <version>2.18.0</version>
+            <version>${camel.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-jms-client</artifactId>
-            <version>1.3.0</version>
+            <version>${artemis.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/distribution/test/itests/test-itests-ddf/pom.xml
+++ b/distribution/test/itests/test-itests-ddf/pom.xml
@@ -194,6 +194,30 @@
             <artifactId>catalog-core-directorymonitor</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+            <version>2.18.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-amqp</artifactId>
+            <version>2.18.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-sjms</artifactId>
+            <version>2.18.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-jms-client</artifactId>
+            <version>1.3.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/MessageBrokerTest.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/MessageBrokerTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2016 Connexta, LLC
+ * <p>
+ * Unlimited Government Rights (FAR Subpart 27.4) Government right to use, disclose, reproduce,
+ * prepare derivative works, distribute copies to the public, and perform and display publicly, in
+ * any manner and for any purpose, and to have or permit others to do so.
+ **/
+package ddf.test.itests.catalog;
+
+import static org.codice.ddf.itests.common.WaitCondition.expect;
+
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.jms.ConnectionFactory;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.sjms.SjmsComponent;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.itests.common.AbstractIntegrationTest;
+import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class MessageBrokerTest extends AbstractIntegrationTest {
+
+    private static final int TIMEOUT_IN_SECONDS = 60;
+
+    private static final String[] REQUIRED_APPS =
+            {"catalog-app", "solr-app", "spatial-app", "broker-app"};
+
+    private static final List<String> LIST_MESSAGES = new ArrayList<>();
+
+    private static CamelContext camelContext;
+
+    @BeforeExam
+    public void beforeExam() throws Exception {
+        basePort = getBasePort();
+        getAdminConfig().setLogLevels();
+
+        getServiceManager().waitForRequiredApps(REQUIRED_APPS);
+        setupCamelContext();
+        configureRestForGuest();
+        getSecurityPolicy().waitForGuestAuthReady(REST_PATH.getUrl() + "?_wadl");
+        FileUtils.copyInputStreamToFile(getFileContentAsStream("sdk-example-route.xml",
+                AbstractIntegrationTest.class), Paths.get(ddfHome, "etc", "routes")
+                .resolve("sdk-example-route.xml")
+                .toFile());
+    }
+
+    @Before
+    public void before() throws Exception {
+        LIST_MESSAGES.clear();
+    }
+
+    @Test
+    public void testDynamicRouting() throws Exception {
+        sendMessage("sjms:jms.queue.sdk.example", "test Message");
+        expect("A message should go through the flow and not be empty").within(TIMEOUT_IN_SECONDS,
+                TimeUnit.SECONDS)
+                .until(() -> !(LIST_MESSAGES.size() == 0) && !StringUtils.isEmpty(LIST_MESSAGES.get(
+                        0)));
+    }
+
+    private void sendMessage(String topicName, String message) throws URISyntaxException {
+        camelContext.createProducerTemplate()
+                .sendBody(topicName, message);
+    }
+
+    private void setupCamelContext() throws Exception {
+        camelContext = new DefaultCamelContext();
+        final ConnectionFactory factory = getServiceManager().getService(ConnectionFactory.class);
+        SjmsComponent sjms = new SjmsComponent();
+        sjms.setConnectionFactory(factory);
+        camelContext.addComponent("sjms", sjms);
+        camelContext.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("sjms:topic:jms.topic.sdk.example").process(exchange -> LIST_MESSAGES.add((String) exchange.getIn()
+                        .getBody()))
+                        .stop();
+            }
+        });
+
+        camelContext.start();
+    }
+}

--- a/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
+++ b/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
@@ -32,6 +32,7 @@
         <bundle>mvn:ddf.test.itests/test-itests-common/${project.version}</bundle>
 
         <bundle>mvn:ddf.test.thirdparty/restito/${project.version}</bundle>
+        <feature>broker-app</feature>
     </feature>
 
     <feature name="third-party-dependencies">


### PR DESCRIPTION
~~We still need a way to copy the route file to the "routes" directory~~

~~Also still need to add a test for the Undelivered Messages UI~~

~~NOTE: This is _NOT_ ready to be merged, at the very least, the route file needs to be copied from the SDK to the routes directory~~